### PR TITLE
php 8.4 compatibility, Implicitly nullable parameter declarations

### DIFF
--- a/src/Imdb/MdbBase.php
+++ b/src/Imdb/MdbBase.php
@@ -54,7 +54,7 @@ class MdbBase extends Config
      * @param LoggerInterface $logger OPTIONAL override default logger `\Imdb\Logger` with a custom one
      * @param CacheInterface $cache OPTIONAL override the default cache with any PSR-16 cache.
      */
-    public function __construct(Config $config = null, LoggerInterface $logger = null, CacheInterface $cache = null)
+    public function __construct(?Config $config = null, ?LoggerInterface $logger = null, ?CacheInterface $cache = null)
     {
         $this->config = $config ?: $this;
         $this->logger = empty($logger) ? new Logger($this->debug) : $logger;


### PR DESCRIPTION
Needed for PHP 8.4, [incompatible with PHP < 7.1](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)