### PR TITLE
return value of name() method in Name class is also null

### DIFF
--- a/src/Imdb/Name.php
+++ b/src/Imdb/Name.php
@@ -114,7 +114,7 @@ class Name extends MdbBase
 
     #------------------------------------------------------------------[ Name ]---
     /** Get the name of the person
-     * @return string name full name of the person
+     * @return string|null name full name of the person
      * @see IMDB person page / (Main page)
      */
     public function name()


### PR DESCRIPTION
Due to recent modifications. I guess more methods should also be reviewed.

Adding value `null` to return since `$this->fullName` can be just `null` (default value)