### PR TITLE
extra check if the object exists in loop while methods graphQlGetAll()

### DIFF
--- a/src/Imdb/Name.php
+++ b/src/Imdb/Name.php
@@ -2134,9 +2134,11 @@ EOF;
         $edges = array();
         while ($hasNextPage) {
             $data = $this->graphql->query($fullQuery, $queryName, ["id" => "nm$this->imdbID", "after" => $endCursor]);
-            $edges = array_merge($edges, $data->name->{$fieldName}->edges);
-            $hasNextPage = $data->name->{$fieldName}->pageInfo->hasNextPage;
-            $endCursor = $data->name->{$fieldName}->pageInfo->endCursor;
+            if ( isset( $data->name->{$fieldName} ) ) {
+                $edges = array_merge($edges, $data->name->{$fieldName}->edges);
+                $hasNextPage = $data->name->{$fieldName}->pageInfo->hasNextPage;
+                $endCursor = $data->name->{$fieldName}->pageInfo->endCursor;
+            }
         }
         return $edges;
     }

--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -3611,9 +3611,11 @@ EOF;
         $edges = array();
         while ($hasNextPage) {
             $data = $this->graphql->query($fullQuery, $queryName, ["id" => "tt$this->imdbID", "after" => $endCursor]);
-            $edges = array_merge($edges, $data->title->{$fieldName}->edges);
-            $hasNextPage = $data->title->{$fieldName}->pageInfo->hasNextPage;
-            $endCursor = $data->title->{$fieldName}->pageInfo->endCursor;
+            if ( isset( $data->title->{$fieldName} ) ) {
+                $edges = array_merge($edges, $data->title->{$fieldName}->edges);
+                $hasNextPage = $data->title->{$fieldName}->pageInfo->hasNextPage;
+                $endCursor = $data->title->{$fieldName}->pageInfo->endCursor;
+            }
         }
         return $edges;
     }


### PR DESCRIPTION
Rational:

The loop `while()` in `graphQlGetAll()` doesn't check if `$data->XXX->{$fieldName}` exists, which may lead to fatal errors, as `array_merge()`cannot merge if `$data->XXX->{$fieldName}` doesn't exist. The `fieldName` may not exist if the query to IMDb doesn't return any data.

The full error message:

`PHP Fatal error array_merge(): Argument #2 must be of type array, null given in imdb-graphql-php/src/Imdb/Name.php:2137`

The change seems pretty straightforward, but I tested anyway without error.