### PR TITLE
param $year is string|null in method fromSearchResult class Title

### DIFF
--- a/src/Imdb/Title.php
+++ b/src/Imdb/Title.php
@@ -102,7 +102,7 @@ class Title extends MdbBase
      * @param string $id imdb ID
      * @param string $title film title
      * @param string $orignalTitle Original film title
-     * @param int $year
+     * @param string|null $year
      * @param string $type
      * @param Config $config
      * @param LoggerInterface $logger OPTIONAL override default logger
@@ -113,7 +113,7 @@ class Title extends MdbBase
         string $id,
         string $title,
         string $orignalTitle,
-        int $year,
+        ?string $year,
         string $type,
         ?Config $config = null,
         ?LoggerInterface $logger = null,


### PR DESCRIPTION
fix bug introduced in https://github.com/duck7000/imdbGraphQLPHP/commit/e6f064dec865665defe6b0b5e8689b79beecdff2

Parameter `$year` in fromSearchResult() is not `int` but `string`, and may also be `null`.