### PR TITLE
Update Logger.php for PSR-3

### DIFF
--- a/src/Imdb/Logger.php
+++ b/src/Imdb/Logger.php
@@ -25,7 +25,6 @@ class Logger implements LoggerInterface
      * @param array $context
      * @return void
      */
-    //public function emergency($message, array $context = array())
     public function emergency(Stringable|string $message, array $context = []): void
     {
         $this->log('emergency', $message, $context);


### PR DESCRIPTION
This fixes PSR-3 interface issues, I was getting this error with PHP 8.4.10:
```
Declaration of Imdb\Logger::emergency($message, array $context = []) must be compatible with Psr\Log\LoggerInterface::emergency(Stringable|string $message, array $context = []): void {"exception":"[object] (Symfony\\Component\\ErrorHandler\\Error\\FatalError(code: 0)
```

And similar for other log functions.